### PR TITLE
Document Quick-Pick Boluses and Meals

### DIFF
--- a/docs/remote/remote-control-overview.md
+++ b/docs/remote/remote-control-overview.md
@@ -185,6 +185,23 @@ If you do not have APNS credentials, you need to create a key and grant it acces
 
 - - -
 
+## Quick-Pick Boluses and Meals
+
+When you open a remote bolus or meal screen, *LoopFollow* may show a row of **Quick-Pick** buttons at the top. Tapping a button fills in the entry fields with that amount — nothing is sent until you review and confirm on the screen as usual.
+
+Quick-Picks are shown on:
+
+* *Trio* Remote Control: **Bolus** screen and **Meal** screen
+* *Loop* Remote Control: **Bolus** screen and **Carbs** screen
+
+The buttons are built from the entries you have successfully sent in the past, scored by:
+
+* **Time of day** — entries used at similar times score higher
+* **Day of week** — weekday and weekend patterns are kept separate
+* **Recency** — older entries gradually fade out
+
+Up to five suggestions are shown, and the section is hidden entirely until there is enough history. The history is stored only on this device.
+
 ## Next Step
 
 Depending on the selection you made, continue to one of these pages for more information on how to configure *LoopFollow* for your desired remote control option.


### PR DESCRIPTION
## Summary

Adds a new **Quick-Pick Boluses and Meals** section to the *Remote Control Overview* page describing the contextual shortcut buttons that appear at the top of the remote bolus, meal, and carbs entry screens.

The section covers:

- Which screens show Quick-Pick buttons (*Trio* Remote Control bolus and meal, *Loop* Remote Control bolus and carbs)
- That tapping a button fills in the entry fields and nothing is sent until the user reviews and confirms
- How the suggestions are scored (time of day, day of week, recency)
- The five-entry cap, that the section is hidden until there is enough history, and that history is stored locally on the device

## Companion PR

Implementation: [loopandlearn/LoopFollow#603](https://github.com/loopandlearn/LoopFollow/pull/603)