### PR TITLE
Document Show Yesterday's BG graph option

### DIFF
--- a/docs/setup/lf-setup.md
+++ b/docs/setup/lf-setup.md
@@ -219,6 +219,7 @@ These settings are accessed through the Graph row in the Settings screen.
 | Show Midnight Lines | Enable or Disable |
 | Show Calibration | Enable or Disable |
 | Show Carb Absorption | Enable or Disable |
+| Show Yesterday's BG | When enabled, yesterday's glucose is overlaid on the main graph as a dimmed gray line, time-shifted 24 hours so it aligns with the same clock time today, for visual comparison<br>*Nightscout* only (Dexcom Share does not return enough history); default off |
 | Treatments on Small Graph | Enable or Disable |
 | Height | Select height of small Graph |
 | Hours of Prediction | Select prediction extent on main plot |


### PR DESCRIPTION
Documents the **Show Yesterday's BG** option (LoopFollow code PR #665), which overlays yesterday's glucose curve on the main graph as a dimmed comparison line.

## Changes
- Adds a `Show Yesterday's BG` row to the Graph settings table in `docs/setup/lf-setup.md`.
- Notes the key constraints: it's a dimmed gray line shifted 24h to align with the same clock time today, *Nightscout* only (Dexcom Share lacks the history), and off by default.
