### PR TITLE
Clarify Contact complication requires Full Access to contacts

### DIFF
--- a/docs/setup/lf-features.md
+++ b/docs/setup/lf-features.md
@@ -184,8 +184,7 @@ Bullet List with Instructions:
     * Open the *LoopFollow* app on your iPhone
     * Go to Settings > Integrations > Contact
     * Toggle on “Enable Contact BG Updates”
-        * If a permission prompt appears, you must grant **Full Access** to your contacts
-            * On iOS 18 and later, the prompt has two steps: first tap “Allow”, then choose **“Allow Full Access”** (do **not** choose “Select Contacts…” / Limited Access)
+        * If a permission prompt appears, choose **“Allow Full Access”** (do **not** choose “Select Contacts…” / Limited Access)
             * *LoopFollow* needs Full Access because it creates and keeps its own *LoopFollow* – BG contact up to date; Limited Access will prevent the complication from updating
         * (The app will automatically create a contact named *LoopFollow* – BG for you.)
 2. Open the Watch App

--- a/docs/setup/lf-features.md
+++ b/docs/setup/lf-features.md
@@ -185,7 +185,7 @@ Bullet List with Instructions:
     * Go to Settings > Integrations > Contact
     * Toggle on “Enable Contact BG Updates”
         * If a permission prompt appears, you must grant **Full Access** to your contacts
-            * On iOS 18 and later (including iOS 26), the prompt has two steps: first tap “Allow”, then choose **“Allow Full Access”** (do **not** choose “Select Contacts…” / Limited Access)
+            * On iOS 18 and later, the prompt has two steps: first tap “Allow”, then choose **“Allow Full Access”** (do **not** choose “Select Contacts…” / Limited Access)
             * *LoopFollow* needs Full Access because it creates and keeps its own *LoopFollow* – BG contact up to date; Limited Access will prevent the complication from updating
         * (The app will automatically create a contact named *LoopFollow* – BG for you.)
 2. Open the Watch App

--- a/docs/setup/lf-features.md
+++ b/docs/setup/lf-features.md
@@ -184,7 +184,9 @@ Bullet List with Instructions:
     * Open the *LoopFollow* app on your iPhone
     * Go to Settings > Integrations > Contact
     * Toggle on “Enable Contact BG Updates”
-        * If a permission prompt appears, tap “Allow” to let *LoopFollow* access your contacts
+        * If a permission prompt appears, you must grant **Full Access** to your contacts
+            * On iOS 18 and later (including iOS 26), the prompt has two steps: first tap “Allow”, then choose **“Allow Full Access”** (do **not** choose “Select Contacts…” / Limited Access)
+            * *LoopFollow* needs Full Access because it creates and keeps its own *LoopFollow* – BG contact up to date; Limited Access will prevent the complication from updating
         * (The app will automatically create a contact named *LoopFollow* – BG for you.)
 2. Open the Watch App
     * On your iPhone, open the Watch app


### PR DESCRIPTION
The watch Contact complication setup just told users to tap "Allow." The contacts prompt now lets users pick Full Access or Limited Access ("Select Contacts…").

LoopFollow needs **Full Access** to create and keep its *LoopFollow – BG* contact updated; Limited Access breaks the complication. The setup steps now say this and warn against choosing Limited Access.