### PR TITLE
Update minimum iOS requirement to iOS 18

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ See [New Feature Highlights](faqs/lf-history.md#new-feature-highlights){: target
 
 ## Hardware Requirements
 
-The *LoopFollow* app will run on any iPhone or iPad that supports iOS 16.6 or newer operating system and on any Mac computer with an Apple Silicon chip, i.e., M1, M2, M3, M4, etc.
+The *LoopFollow* app will run on any iPhone or iPad that supports iOS 18 or newer operating system and on any Mac computer with an Apple Silicon chip, i.e., M1, M2, M3, M4, etc.
 
 - - -
 


### PR DESCRIPTION
Updates the Hardware Requirements section to reflect that LoopFollow now requires iOS 18 or newer, up from iOS 16.6.

The deployment target was raised to iOS 18 on the `dev` branch to adopt Apple's Swift Charts framework for the modernized graphs. This applies to the next release; the current released version (6.2.0) still supports iOS 16.6.

Telemetry check before making the change: of 1,134 devices active in the last 30 days, only 10 (0.9%) are on an iOS older than 18, and most of those are on hardware that cannot upgrade past it (iPhone 8, iPad 5th/6th generation).

**Merge timing:** this should land together with the release that ships the iOS 18 requirement, so the docs don't get ahead of `main`.
