### PR TITLE
Document Nightscout database size info row and alarm

### DIFF
--- a/docs/setup/lf-features.md
+++ b/docs/setup/lf-features.md
@@ -75,6 +75,7 @@ The table below lists every alarm type available in *LoopFollow*, organized by g
 | Sensor Change Alert | Sensor change due |
 | Not Looping Alert | Loop hasn't completed within a configurable number of minutes |
 | Looping app expiration | Looping-app build is expiring soon |
+| Nightscout Database Size | *Nightscout* database has filled to or above a chosen percentage of its configured size limit (defaults to 75%, daytime only) |
 
 #### Override / Target
 

--- a/docs/setup/lf-setup.md
+++ b/docs/setup/lf-setup.md
@@ -265,6 +265,10 @@ These items can be chosen for display on the Home screen. A Nightscout Site is r
 | Updated | Time of last `loop` | `Trio` |
 | TDD | Total Daily Dose in the last 24 hours | `Trio` |
 | IAGE | Insulin Age | Both |
+| DB Size | *Nightscout* database size: used MiB and the percentage of the site's configured limit. Hidden by default | Both |
+
+!!! note "DB Size"
+    The **DB Size** row and the [*Nightscout* Database Size alarm](lf-features.md#alarms){: target="_blank" } both read from *Nightscout*'s `dbsize` plugin, so your site must have that plugin enabled. The percentage is measured against the site's `DBSIZE_MAX` setting, which is **496 MiB** unless the site owner changed it. Because that setting may not match your hosting plan's real limit, the row leads with the absolute used MiB figure, which is always meaningful.
 
 ### Units and Metrics
 

--- a/docs/setup/lf-setup.md
+++ b/docs/setup/lf-setup.md
@@ -265,10 +265,10 @@ These items can be chosen for display on the Home screen. A Nightscout Site is r
 | Updated | Time of last `loop` | `Trio` |
 | TDD | Total Daily Dose in the last 24 hours | `Trio` |
 | IAGE | Insulin Age | Both |
-| DB Size | *Nightscout* database size: used MiB and the percentage of the site's configured limit. Hidden by default | Both |
+| DB Size | *Nightscout* database size: Megabytes (MB) used and the percentage of the site's configured limit. Hidden by default | Both |
 
 !!! note "DB Size"
-    The **DB Size** row and the [*Nightscout* Database Size alarm](lf-features.md#alarms){: target="_blank" } both read from *Nightscout*'s `dbsize` plugin, so your site must have that plugin enabled. The percentage is measured against the site's `DBSIZE_MAX` setting, which is **496 MiB** unless the site owner changed it. Because that setting may not match your hosting plan's real limit, the row leads with the absolute used MiB figure, which is always meaningful.
+    The **DB Size** row and the [*Nightscout* Database Size alarm](lf-features.md#alarms){: target="_blank" } both read from *Nightscout*'s `dbsize` plugin, so your site must have that plugin enabled. The percentage is measured against the site's `DBSIZE_MAX` setting, which is **496 MB** unless the site owner changed it. Because that setting may not match your hosting plan's real limit, the row leads with the absolute used MB figure, which is always meaningful.
 
 ### Units and Metrics
 


### PR DESCRIPTION
Documents the new Nightscout database size monitoring added to the app.

- **Information Display** (`lf-setup.md`): adds the **DB Size** row — used MiB and the percentage of the site's configured limit, hidden by default — plus a note explaining that it reads from Nightscout's `dbsize` plugin and that the percentage is measured against `DBSIZE_MAX` (496 MiB unless the site owner changed it), which is why the row leads with the absolute MiB figure.
- **Alarm Types Reference** (`lf-features.md`): adds the **Nightscout Database Size** alarm under Device / System, noting the 75% default and daytime-only default.

Documents app PR loopandlearn/LoopFollow#697.