### PR TITLE
Document search in alarms list, Add Alarm sheet, and Menu

### DIFF
--- a/docs/setup/lf-features.md
+++ b/docs/setup/lf-features.md
@@ -8,6 +8,8 @@ Most features and the settings that control them are self-explanatory and docume
 
 When you select the Alarms Feature, the initial screen will be blank. By tapping on the plus sign upper right, you can add as many alarms as desired. There is quick access to the overall [Alarm Settings](lf-setup.md#alarms) by tapping the gear icon on this screen.
 
+Both the alarms list and the **Add Alarm** sheet have a search field. On the alarms list, type to filter your configured alarms by name or alarm type. In the **Add Alarm** sheet, type to filter the available alarm types by name, description, or group — non-matching groups are hidden. When nothing matches, a **No Results** message is shown.
+
 The graphic below shows a few typical alarms that might be chosen.
 
 ![example alarm screen](img/lf-alarms-screen.png){width="350"}

--- a/docs/setup/lf-setup.md
+++ b/docs/setup/lf-setup.md
@@ -66,6 +66,8 @@ The following graphic shows the menu screen. The menu can always be reached usin
 * Settings, Logging and Build Information are covered below
 * [Support & Community](../index.md#community-support-and-build-help){: target="_blank" } are discussed on the *LoopFollowDocs* home page
 
+The Menu has a search field. Type to filter the menu's own rows (Settings, the tab features, View Log / Share Logs, and the support links) as well as the rows inside the Settings screen (General, Graph, Units and Metrics, Alarms, …). Selecting a Settings result opens that screen directly. An empty search shows the normal menu; a query with no matches shows a **No Results** state.
+
 
 ![Menu screen for *LoopFollow*](img/lf-menu.svg){width=400}
 {align="center"}


### PR DESCRIPTION
Documents the search fields added across the app in release 7.

- **Alarms feature** (`lf-features.md`): notes that both the alarms list and the Add Alarm sheet can be filtered by typing — the list matches configured name or alarm type, the Add Alarm sheet matches name/description/group and hides non-matching groups — with a No Results state.
- **Menu screen** (`lf-setup.md`): notes the Menu search that filters the menu's own rows plus the Settings sub-screen rows and deep-links into a selected settings screen.

Documents app PRs loopandlearn/LoopFollow#681, loopandlearn/LoopFollow#694, and loopandlearn/LoopFollow#695.